### PR TITLE
Issue98fix

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -626,8 +626,8 @@ func testMultiOp(t *testing.T, c *zk.Conn) {
 	ops = []interface{}{
 		&zk.CreateRequest{Path: "/foo", Data: []byte("foo"), Acl: acl},
 	}
-	if _, err := c.Multi(ops...); err == nil || err.Error() != zetcd.ErrAPIError.Error() {
-		t.Fatalf("expected %v, got %v", zetcd.ErrAPIError, err)
+	if _, err := c.Multi(ops...); err == nil || err.Error() != zetcd.ErrNodeExists.Error() {
+		t.Fatalf("expected %v, got %v", zetcd.ErrNodeExists, err)
 	}
 	// test create+delete on same key == no key
 	ops = []interface{}{
@@ -653,8 +653,8 @@ func testMultiOp(t *testing.T, c *zk.Conn) {
 		&zk.CheckVersionRequest{Path: "/foo", Version: 2},
 	}
 	_, err = c.Multi(ops...)
-	if err == nil || err.Error() != zetcd.ErrAPIError.Error() {
-		t.Fatalf("expected %v, got %v", zetcd.ErrAPIError, err)
+	if err == nil || err.Error() != zetcd.ErrBadVersion.Error() {
+		t.Fatalf("expected %v, got %v", zetcd.ErrBadVersion, err)
 	}
 	if _, s1, err = c.Get("/test1"); err == nil || err.Error() != zetcd.ErrNoNode.Error() {
 		t.Fatalf("expected %v, got (%v,%v)", zetcd.ErrNoNode, s1, err)
@@ -681,8 +681,8 @@ func testMultiOp(t *testing.T, c *zk.Conn) {
 	ops = []interface{}{
 		&zk.CheckVersionRequest{Path: "/missing-key", Version: 0},
 	}
-	if _, err = c.Multi(ops...); err == nil || err.Error() != zetcd.ErrAPIError.Error() {
-		t.Fatalf("expected %v, got %v", zetcd.ErrAPIError, err)
+	if _, err = c.Multi(ops...); err == nil || err.Error() != zetcd.ErrNoNode.Error() {
+		t.Fatalf("expected %v, got %v", zetcd.ErrNoNode, err)
 	}
 	// test empty operation list
 	if resp, err = c.Multi(); err != nil || len(resp) != 0 {

--- a/zketcd.go
+++ b/zketcd.go
@@ -536,7 +536,6 @@ func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 		return reply(xid, zxid)
 	}
 
-	fmt.Printf("Multi(%v) = (zxid=%v); txnresp: %+v\n", *mreq, resp.Header.Revision, *resp)
 	return reply(xid, ZXid(resp.Header.Revision))
 }
 

--- a/zketcd.go
+++ b/zketcd.go
@@ -524,7 +524,7 @@ func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 				mresp.Ops[i].Stat = &r.Stat
 			}
 		}
-		return mkZKResp(xid, zxid, mresp)
+		return mkZKPartialResp(xid, zxid, mresp, mresp.DoneHeader.Err)
 	}
 
 	resp, _ := z.doSTM(apply, prefetch...)
@@ -726,6 +726,10 @@ func mkZKErr(xid Xid, zxid ZXid, err ErrCode) ZKResponse {
 
 func mkZKResp(xid Xid, zxid ZXid, resp interface{}) ZKResponse {
 	return ZKResponse{Hdr: &ResponseHeader{xid, zxid - 1, 0}, Resp: resp}
+}
+
+func mkZKPartialResp(xid Xid, zxid ZXid, resp interface{}, err ErrCode) ZKResponse {
+	return ZKResponse{Hdr: &ResponseHeader{xid, zxid - 1, err}, Resp: resp}
 }
 
 // wrapErr is to pass back error info but still get the txn response

--- a/zketcd.go
+++ b/zketcd.go
@@ -470,15 +470,23 @@ func (z *zkEtcd) Sync(xid Xid, op *SyncRequest) ZKResponse {
 
 func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 	bs := make([]opBundle, len(mreq.Ops))
+	mresp := &MultiResponse{
+		Ops:        make([]MultiResponseOp, len(mreq.Ops)),
+		DoneHeader: MultiHeader{Type: opMulti},
+	}
 	for i, op := range mreq.Ops {
 		switch req := op.Op.(type) {
 		case *CreateRequest:
 			bs[i] = z.mkCreateTxnOp(req)
+			mresp.Ops[i].Header.Type = opCreate
 		case *DeleteRequest:
 			bs[i] = z.mkDeleteTxnOp(req)
+			mresp.Ops[i].Header.Type = opDelete
 		case *SetDataRequest:
 			bs[i] = z.mkSetDataTxnOp(req)
+			mresp.Ops[i].Header.Type = opSetData
 		case *CheckVersionRequest:
+			mresp.Ops[i].Header.Type = opCheck
 			bs[i] = z.mkCheckVersionPathTxnOp(req)
 		default:
 			panic(fmt.Sprintf("unknown multi %+v %T", op.Op, op.Op))
@@ -491,8 +499,15 @@ func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 	}
 
 	apply := func(s v3sync.STM) error {
-		for _, b := range bs {
+		for i, b := range bs {
 			if err := b.apply(s); err != nil {
+				var ok bool
+				if mresp.Ops[i].Header.Err, ok = errorToErrCode[err]; !ok {
+					mresp.Ops[i].Header.Err = errAPIError
+				}
+				if mresp.DoneHeader.Err == 0 {
+					mresp.DoneHeader.Err = mresp.Ops[i].Header.Err
+				}
 				return err
 			}
 		}
@@ -500,52 +515,29 @@ func (z *zkEtcd) Multi(xid Xid, mreq *MultiRequest) ZKResponse {
 	}
 
 	reply := func(xid Xid, zxid ZXid) ZKResponse {
-		ops := make([]MultiResponseOp, len(bs))
 		for i, b := range bs {
 			resp := b.reply(xid, zxid)
-			ops[i].Header = MultiHeader{Err: 0}
 			switch r := resp.Resp.(type) {
 			case *CreateResponse:
-				ops[i].Header.Type = opCreate
-				ops[i].String = r.Path
+				mresp.Ops[i].String = r.Path
 			case *SetDataResponse:
-				ops[i].Header.Type = opSetData
-				ops[i].Stat = &r.Stat
-			case *DeleteResponse:
-				ops[i].Header.Type = opDelete
-			case *struct{}:
-				ops[i].Header.Type = opCheck
-			default:
-				panic(fmt.Sprintf("unknown multi %+v %T", resp, resp))
+				mresp.Ops[i].Stat = &r.Stat
 			}
-		}
-		mresp := &MultiResponse{
-			Ops:        ops,
-			DoneHeader: MultiHeader{Type: opMulti},
 		}
 		return mkZKResp(xid, zxid, mresp)
 	}
 
-	resp, err := z.doSTM(apply, prefetch...)
+	resp, _ := z.doSTM(apply, prefetch...)
 	if resp == nil {
-		// txn aborted, possibly due to any API error
-		if _, ok := errorToErrCode[err]; !ok {
-			// aborted due to non-API error
-			return mkErr(err)
-		}
 		zxid, zerr := z.incrementAndGetZxid()
 		if zerr != nil {
 			return mkErr(zerr)
 		}
-		// zkdocker seems to always return API error...
-		zkresp := apiErrToZKErr(xid, zxid, err)
-		zkresp.Hdr.Err = errAPIError
-		return zkresp
+		return reply(xid, zxid)
 	}
 
-	mresp := reply(xid, ZXid(resp.Header.Revision))
-	glog.V(7).Infof("Multi(%v) = (zxid=%v); txnresp: %+v", *mreq, resp.Header.Revision, *resp)
-	return mresp
+	fmt.Printf("Multi(%v) = (zxid=%v); txnresp: %+v\n", *mreq, resp.Header.Revision, *resp)
+	return reply(xid, ZXid(resp.Header.Revision))
 }
 
 func (z *zkEtcd) mkCheckVersionPathTxnOp(op *CheckVersionRequest) opBundle {


### PR DESCRIPTION
zketcd: return partial results from a failed multi-op request

Zookeeper can return partial results from a multi-op request, 
which Kafka 2.1.x is relying on.  If the second op fails, but the 
first one succeeds then Kafka expects two results and throws
a NPE if not there.

Fixes #98 