### PR TITLE
testing: repair docker cross check tests

### DIFF
--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -53,7 +53,7 @@ func NewContainer(containerName, dockerFile string, ports []string) (*Container,
 }
 
 func newContainerFiles(cfg ContainerConfig) (c *Container, err error) {
-	dc, err := docker.NewClient("unix://var/run/docker.sock")
+	dc, err := docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
 		return nil, err
 	}

--- a/integration/drill/Dockerfile
+++ b/integration/drill/Dockerfile
@@ -1,12 +1,14 @@
 FROM java:openjdk-8-jdk
 # needs jdk to submit sql queries!?
 
+ENV DRILL_VERSION 1.15.0
+
 RUN	mkdir -p /opt/drill && \
-	wget -q -O - http://www-us.apache.org/dist/drill/drill-1.10.0/apache-drill-1.10.0.tar.gz | tar -zxvf  - -C /opt/drill
+	wget -q -O - http://www-us.apache.org/dist/drill/drill-${DRILL_VERSION}/apache-drill-${DRILL_VERSION}.tar.gz | tar -zxvf  - -C /opt/drill
 
 EXPOSE 8047
 
-ENV DRILL_HOME		/opt/drill/apache-drill-1.10.0
+ENV DRILL_HOME		/opt/drill/apache-drill-${DRILL_VERSION}
 ENV DRILL_LOG_DIR	${DRILL_HOME}/log/
 ENV DRILL_LOG_PREFIX	${DRILL_LOG_PATH}/drill
 
@@ -23,8 +25,8 @@ ENTRYPOINT ["java",\
 	"-Ddrill.exec.enable-epoll=false",\
 	"-XX:+CMSClassUnloadingEnabled",\
 	"-XX:+UseG1GC",\
-	"-Dlog.path=/opt/drill/apache-drill-1.10.0/log/drillbit.log",\
-	"-Dlog.query.path=/opt/drill/apache-drill-1.10.0/log/drillbit_queries.json",\
+	"-Dlog.path=/opt/drill/apache-drill-${DRILL_VERSION}/log/drillbit.log",\
+	"-Dlog.query.path=/opt/drill/apache-drill-${DRILL_VERSION}/log/drillbit_queries.json",\
 	"-cp",\
-	"/opt/drill/apache-drill-1.10.0/conf:/opt/drill/apache-drill-1.10.0/jars/*:/opt/drill/apache-drill-1.10.0/jars/ext/*:/opt/drill/apache-drill-1.10.0/jars/3rdparty/*:/opt/drill/apache-drill-1.10.0/jars/classb/*",\
+	"/opt/drill/apache-drill-${DRILL_VERSION}/conf:/opt/drill/apache-drill-${DRILL_VERSION}/jars/*:/opt/drill/apache-drill-${DRILL_VERSION}/jars/ext/*:/opt/drill/apache-drill-${DRILL_VERSION}/jars/3rdparty/*:/opt/drill/apache-drill-${DRILL_VERSION}/jars/classb/*",\
 	"org.apache.drill.exec.server.Drillbit"]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -15,7 +15,6 @@
 package integration
 
 import (
-	"net"
 	"testing"
 	"time"
 
@@ -555,26 +554,6 @@ func TestCreateInvalidPath(t *testing.T) {
 			t.Errorf("got err %v, wanted %v", err, werr)
 		}
 	})
-}
-
-func TestRUOK(t *testing.T) {
-	zkclus := newZKCluster(t)
-	defer zkclus.Close(t)
-
-	conn, err := net.Dial("tcp", zkclus.Addr())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := conn.Write([]byte("ruok")); err != nil {
-		t.Fatal(err)
-	}
-	buf := make([]byte, 4)
-	if _, err := conn.Read(buf); err != nil {
-		t.Fatal(err)
-	}
-	if string(buf) != "imok" {
-		t.Fatalf(`expected "imok", got %q`, string(buf))
-	}
 }
 
 func TestMultiOp(t *testing.T) { runTest(t, testMultiOp) }

--- a/integration/integration_zetcd_test.go
+++ b/integration/integration_zetcd_test.go
@@ -1,0 +1,28 @@
+// +build !zkdocker,!xchk
+
+package integration
+
+import (
+	"net"
+	"testing"
+)
+
+func TestRUOK(t *testing.T) {
+	zkclus := newZKCluster(t)
+	defer zkclus.Close(t)
+
+	conn, err := net.Dial("tcp", zkclus.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("ruok")); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 4)
+	if _, err := conn.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "imok" {
+		t.Fatalf(`expected "imok", got %q`, string(buf))
+	}
+}

--- a/integration/kafka/Dockerfile
+++ b/integration/kafka/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get install -y wget supervisor dnsutils
 RUN rm -rf /var/lib/apt/lists/*; apt-get clean
 
 ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 0.11.0.0
+ENV KAFKA_VERSION 0.11.0.3
 RUN wget -q http://www-us.apache.org/dist/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
 RUN tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && mv /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION" /kafka
 # 9092 is kafka port


### PR DESCRIPTION
The xchk with docker integration tests are broken.  The docker files were
attempting to download old versions of Kafka and Drill that no longer
existed on the servers.  In addition the RUOK test was causing all tests
to hang in the docker mode by causing a NPE Zookeeper and never
completely starting up.