### PR TITLE
revoke session when closing

### DIFF
--- a/session.go
+++ b/session.go
@@ -88,6 +88,7 @@ func (s *session) Sid() Sid { return Sid(s.id) }
 func (s *session) Close() {
 	s.watches.close()
 	s.Conn.Close()
+	s.c.Revoke(s.c.Ctx(), s.id)
 }
 
 // ZXid gets the lease ZXid


### PR DESCRIPTION
Looks like `Conn`, `watches` and `id etcd.LeaseID` of zetcd.session are resources that associate a particular zookeeper client. I am expecting all of them are closing together. 
However, `Conn` and `watches` close when the session.Close() is calling, and `lease` will be revoked after getting a CloseRequest from zookeeper client.
When I am facing the edge case that zookeeper client power off or kill -9, there is no CloseRequest at all. The Session will keep the lease forever instead of revoking.
So I am wondering, shall we revoke the lease during session closing?