### PR TITLE
cleanup: remove ioutil for new go version

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -16,7 +16,7 @@ package zetcd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 	"time"
@@ -31,7 +31,7 @@ const (
 
 var acl = zk.WorldACL(zk.PermAll)
 
-func init() { zk.DefaultLogger = log.New(ioutil.Discard, "", 0) }
+func init() { zk.DefaultLogger = log.New(io.Discard, "", 0) }
 
 func benchGet(b *testing.B, addr string) {
 	c, _, err := zk.Connect([]string{addr}, time.Second)

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -20,12 +20,9 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/fsouza/go-dockerclient"
 )
 
 type Container struct {
@@ -129,7 +126,7 @@ func buildTar(files ...string) (io.Reader, error) {
 	defer tr.Close()
 	now := time.Now()
 	for _, f := range files {
-		dat, derr := ioutil.ReadFile(f)
+		dat, derr := os.ReadFile(f)
 		if derr != nil {
 			return nil, derr
 		}


### PR DESCRIPTION
Remove ioutil for new go version
The io/ioutil package has been deprecated from go 1.16: https://go.dev/doc/go1.16#ioutil